### PR TITLE
New Student Info Page

### DIFF
--- a/src/app/newstudents/page.tsx
+++ b/src/app/newstudents/page.tsx
@@ -1,0 +1,55 @@
+import { SectionTitle } from "@components/SectionTitle";
+import { InfoCard } from "@components/InfoCard";
+import { STORIES, TODAY_STATISTICS } from "@data";
+import { Sponsors } from "@components/Sponsors";
+import { TitleSubtitle } from "@components/TitleSubtitle";
+
+const NewStudents = () => {
+  return (
+    <div className="flex justify-center items-center flex-col">
+      <SectionTitle
+        title="New to Yale?"
+        subtitle="Welcome to Yale, Class of 2028! Learn how to access Y/CS Products and the best tech at Yale."
+      />
+
+      <div
+        className="bg-ycs-gray p-8 md:p-12 m-8 md:m-12 mb-0 md:mb-0 text-lg md:text-2xl"
+        style={{
+          borderRadius: 40,
+        }}
+      >
+        <text>
+          Y/CS products such as Yalies and Coursetable respect Yale's matriculation process and access is not granted until you are set to an active student in Yale's system.
+          You are considered an incoming student from the time you accept Yale's offer of admission to early August. 
+          In August, this status will change to active and you should log out and log in again on CourseTable to refresh your authentication status.
+          The Y/CS is unable to manually grant access or change your student status, as this is all handled centrally by the University Registrar's Office.
+        </text>
+      </div>
+
+      <TitleSubtitle
+        title="While You're Waiting"
+        subtitle="Learn what you can use to get the most out of your Yale Experience!"
+        className="mb-10 mt-32"
+      />
+
+      <div className="flex flex-col md:flex-row pt-10 gap-16 md:gap-4 mx-10">
+        {STORIES.map((story, i) => (
+          <InfoCard data={story.data} description={story.description} key={i} />
+        ))}
+      </div>
+
+      <TitleSubtitle title="Today" subtitle="By the Numbers" className="mb-10 mt-32" />
+
+      <div className="flex flex-col md:flex-row pt-10 gap-16 md:gap-4 mx-10">
+        {TODAY_STATISTICS.map((story, i) => (
+          <InfoCard data={story.data} description={story.description} key={i} />
+        ))}
+      </div>
+
+      <Sponsors />
+      <div className="mt-20" />
+    </div>
+  );
+};
+
+export default NewStudents;

--- a/src/app/newstudents/page.tsx
+++ b/src/app/newstudents/page.tsx
@@ -1,7 +1,7 @@
 import { SectionTitle } from "@components/SectionTitle";
-import { InfoCard } from "@components/InfoCard";
-import { STORIES, TODAY_STATISTICS } from "@data";
-import { Sponsors } from "@components/Sponsors";
+//import { InfoCard } from "@components/InfoCard";
+//import { STORIES, TODAY_STATISTICS } from "@data";
+//import { Sponsors } from "@components/Sponsors";
 import { TitleSubtitle } from "@components/TitleSubtitle";
 
 const NewStudents = () => {
@@ -19,36 +19,20 @@ const NewStudents = () => {
         }}
       >
         <text>
-          Y/CS products such as Yalies and Coursetable respect Yale's matriculation process and access is not granted until you are set to an active student in Yale's system.
+          Y/CS products such as Yalies and Coursetable respect Yale's matriculation process;
+          Access to products are not granted until you are set to an active student in Yale's system.
           You are considered an incoming student from the time you accept Yale's offer of admission to early August. 
           In August, this status will change to active and you should log out and log in again on CourseTable to refresh your authentication status.
           The Y/CS is unable to manually grant access or change your student status, as this is all handled centrally by the University Registrar's Office.
         </text>
       </div>
-
-      <TitleSubtitle
+   <TitleSubtitle
         title="While You're Waiting"
         subtitle="Learn what you can use to get the most out of your Yale Experience!"
         className="mb-10 mt-32"
       />
 
-      <div className="flex flex-col md:flex-row pt-10 gap-16 md:gap-4 mx-10">
-        {STORIES.map((story, i) => (
-          <InfoCard data={story.data} description={story.description} key={i} />
-        ))}
-      </div>
-
-      <TitleSubtitle title="Today" subtitle="By the Numbers" className="mb-10 mt-32" />
-
-      <div className="flex flex-col md:flex-row pt-10 gap-16 md:gap-4 mx-10">
-        {TODAY_STATISTICS.map((story, i) => (
-          <InfoCard data={story.data} description={story.description} key={i} />
-        ))}
-      </div>
-
-      <Sponsors />
-      <div className="mt-20" />
-    </div>
+    </div> 
   );
 };
 

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,7 +11,7 @@ export const navigationItems = [
   { name: "Products", link: "/products" },
   { name: "Events", link: "/events" },
   { name: "Team", link: "/team" },
-  { name: "Incoming Students", link: /"newstudents" },
+  { name: "Incoming Students", link: "/newstudents" },
   { name: "Join", link: "/join" },
   {
     name: "Feedback",

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,7 @@ export const navigationItems = [
   { name: "Products", link: "/products" },
   { name: "Events", link: "/events" },
   { name: "Team", link: "/team" },
+  { name: "Incoming Students", link: /"newstudents" },
   { name: "Join", link: "/join" },
   {
     name: "Feedback",


### PR DESCRIPTION
Comms often gets emails from new students asking for early access or errors on accessing Y/CS products. Significant time is spent answering these. Proposing an new page just for our new students to answer:

1. When we grant access (early/mid august, based on University Registrar's Office removing the incoming student tag)
2. Y/CS products they can look forward to

## Proof of concept

<img width="950" alt="2024-07-29 22_21_52-" src="https://github.com/user-attachments/assets/3cc58cc7-6719-41e9-8616-4d4855fc44cc">
